### PR TITLE
Feat: 네비게이션 로고 텍스트 패딩 수정

### DIFF
--- a/src/components/navbar/styles.ts
+++ b/src/components/navbar/styles.ts
@@ -68,13 +68,13 @@ const styles = {
 
   // 텍스트 애니메이션 (접기/펼치기)
   textCollapsed: 'opacity-0 w-0 overflow-hidden pl-0',
-  textExpanded: 'opacity-100',
+  textExpanded: 'opacity-100 pl-2',
   textTransition: 'font-medium transition-all duration-300 whitespace-nowrap',
 
   // 브랜딩
   brandingTitle: 'text-white text-3xl font-bold font-agbalumo cursor-default',
   brandingTitleCollapsed:
-    'text-white text-3xl font-bold tracking-wide transition-all duration-300 font-agbalumo pl-2 cursor-default',
+    'text-white text-3xl font-bold tracking-wide transition-all duration-300 font-agbalumo cursor-default',
 
   // 활성 표시기
   activeIndicator:


### PR DESCRIPTION
## 🎀 What Did You Do

- [x] 네비게이션 로고 텍스트 패딩 수정

## 🐶 Screenshots (optional)

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/8d2de28c-39a0-465f-9c40-7cb34129d0fd" height="200" /><p>수정 전</p></td>
    <td><img src="https://github.com/user-attachments/assets/4db10ac3-02be-47f5-b7b5-a027a7a389e8" height="200" /><p>수정 후</p></td>
  </tr>
</table>

## 🔍 How to Test

1. 네비게이션 사이드바를 좁히기
2. 네비게이션 넓히는 아이콘에 대한 기존 좌측 패딩이 없어졌는지 확인

## ✨ Etc

e.g., References, comments for the code review
